### PR TITLE
feat: 検索結果のソート機能追加

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -12,6 +12,13 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const keyword = searchParams.get("q");
 
+    // Sort parameter
+    const VALID_SORT_BY = ["submittedDate", "relevance", "lastUpdatedDate"];
+    const sortByParam = searchParams.get("sortBy") || "submittedDate";
+    const sortBy = VALID_SORT_BY.includes(sortByParam)
+      ? sortByParam
+      : "submittedDate";
+
     // Construct query
     // If keyword is provided, search in all fields for that keyword within cs.RO category
     // Otherwise use the default complex query
@@ -21,7 +28,7 @@ export async function GET(request: Request) {
     }
 
     // 1. Fetch from arXiv
-    const query = `search_query=${encodeURIComponent(apiQuery)}&start=0&max_results=${MAX_RESULTS}&sortBy=submittedDate&sortOrder=descending`;
+    const query = `search_query=${encodeURIComponent(apiQuery)}&start=0&max_results=${MAX_RESULTS}&sortBy=${sortBy}&sortOrder=descending`;
     const response = await fetch(`${ARXIV_BASE_URL}?${query}`);
 
     if (!response.ok) {

--- a/src/app/api/youtube/route.ts
+++ b/src/app/api/youtube/route.ts
@@ -21,11 +21,16 @@ export async function GET(request: Request) {
     );
     const pageToken = searchParams.get("pageToken") || "";
 
+    // Sort parameter
+    const VALID_ORDERS = ["date", "relevance", "viewCount", "rating"];
+    const orderParam = searchParams.get("order") || "date";
+    const order = VALID_ORDERS.includes(orderParam) ? orderParam : "date";
+
     const params = new URLSearchParams({
       part: "snippet",
       q: query,
       type: "video",
-      order: "date",
+      order,
       maxResults: String(maxResults),
       regionCode: "JP",
       key: YOUTUBE_API_KEY,

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+export type PaperSortOption = "submittedDate" | "relevance" | "lastUpdatedDate";
+export type YouTubeSortOption = "date" | "relevance" | "viewCount" | "rating";
+
 type HeaderProps = {
   activeTab: "papers" | "youtube";
   onTabChange: (tab: "papers" | "youtube") => void;
@@ -10,6 +13,10 @@ type HeaderProps = {
   onSearch: (e: React.FormEvent) => void;
   searchQuery: string;
   bookmarkCount: number;
+  paperSort: PaperSortOption;
+  youtubeSort: YouTubeSortOption;
+  onPaperSortChange: (sort: PaperSortOption) => void;
+  onYoutubeSortChange: (sort: YouTubeSortOption) => void;
 };
 
 export default function Header({
@@ -22,6 +29,10 @@ export default function Header({
   onSearch,
   searchQuery,
   bookmarkCount,
+  paperSort,
+  youtubeSort,
+  onPaperSortChange,
+  onYoutubeSortChange,
 }: HeaderProps) {
   return (
     <header className="mb-8">
@@ -86,35 +97,68 @@ export default function Header({
         </div>
       </div>
 
-      {/* Tabs */}
+      {/* Tabs + Sort */}
       {!showSavedOnly && (
-        <div className="flex border-b border-slate-200">
-          <button
-            onClick={() => onTabChange("papers")}
-            className={`px-6 py-3 font-medium text-sm transition-colors relative ${
-              activeTab === "papers"
-                ? "text-indigo-700"
-                : "text-slate-500 hover:text-slate-700"
-            }`}
-          >
-            📄 論文
-            {activeTab === "papers" && (
-              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-700 rounded-full" />
+        <div className="flex items-center justify-between border-b border-slate-200">
+          <div className="flex">
+            <button
+              onClick={() => onTabChange("papers")}
+              className={`px-6 py-3 font-medium text-sm transition-colors relative ${
+                activeTab === "papers"
+                  ? "text-indigo-700"
+                  : "text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              📄 論文
+              {activeTab === "papers" && (
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-700 rounded-full" />
+              )}
+            </button>
+            <button
+              onClick={() => onTabChange("youtube")}
+              className={`px-6 py-3 font-medium text-sm transition-colors relative ${
+                activeTab === "youtube"
+                  ? "text-red-600"
+                  : "text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              ▶ YouTube
+              {activeTab === "youtube" && (
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-600 rounded-full" />
+              )}
+            </button>
+          </div>
+
+          {/* Sort dropdown */}
+          <div className="flex items-center gap-2 pb-1">
+            <label className="text-xs text-slate-400">並び替え</label>
+            {activeTab === "papers" ? (
+              <select
+                value={paperSort}
+                onChange={(e) =>
+                  onPaperSortChange(e.target.value as PaperSortOption)
+                }
+                className="text-sm border border-slate-300 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                <option value="submittedDate">📅 新着順</option>
+                <option value="relevance">🔍 関連度順</option>
+                <option value="lastUpdatedDate">🔄 更新日順</option>
+              </select>
+            ) : (
+              <select
+                value={youtubeSort}
+                onChange={(e) =>
+                  onYoutubeSortChange(e.target.value as YouTubeSortOption)
+                }
+                className="text-sm border border-slate-300 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+              >
+                <option value="date">📅 新着順</option>
+                <option value="relevance">🔍 関連度順</option>
+                <option value="viewCount">👁 再生回数順</option>
+                <option value="rating">⭐ 評価順</option>
+              </select>
             )}
-          </button>
-          <button
-            onClick={() => onTabChange("youtube")}
-            className={`px-6 py-3 font-medium text-sm transition-colors relative ${
-              activeTab === "youtube"
-                ? "text-red-600"
-                : "text-slate-500 hover:text-slate-700"
-            }`}
-          >
-            ▶ YouTube
-            {activeTab === "youtube" && (
-              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-600 rounded-full" />
-            )}
-          </button>
+          </div>
         </div>
       )}
     </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { type Paper, type Video, type ContentItem } from "./types";
-import Header from "./components/Header";
+import Header, {
+  type PaperSortOption,
+  type YouTubeSortOption,
+} from "./components/Header";
 import PaperCard from "./components/PaperCard";
 import VideoCard from "./components/VideoCard";
 import SkeletonCard from "./components/SkeletonCard";
@@ -25,6 +28,10 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
   const [keyword, setKeyword] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
+
+  // Sort state
+  const [paperSort, setPaperSort] = useState<PaperSortOption>("submittedDate");
+  const [youtubeSort, setYoutubeSort] = useState<YouTubeSortOption>("date");
 
   // Bookmarks: unified Paper + Video
   const [bookmarks, setBookmarks] = useState<ContentItem[]>([]);
@@ -107,6 +114,7 @@ export default function Home() {
         if (searchQuery) {
           params.set("q", searchQuery);
         }
+        params.set("sortBy", paperSort);
         const res = await fetch(`/api/news?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch data");
         const data = await res.json();
@@ -124,7 +132,7 @@ export default function Home() {
     if (activeTab === "papers" || !videosInitialized) {
       fetchPapers();
     }
-  }, [searchQuery, activeTab, videosInitialized]);
+  }, [searchQuery, activeTab, videosInitialized, paperSort]);
 
   // Fetch YouTube videos
   const fetchVideos = useCallback(
@@ -141,6 +149,7 @@ export default function Home() {
         if (searchQuery) {
           params.set("q", searchQuery);
         }
+        params.set("order", youtubeSort);
         if (pageToken) {
           params.set("pageToken", pageToken);
         }
@@ -165,7 +174,7 @@ export default function Home() {
         setLoadingMore(false);
       }
     },
-    [searchQuery, activeTab],
+    [searchQuery, activeTab, youtubeSort],
   );
 
   // Trigger YouTube fetch when tab switches to youtube or search changes
@@ -185,6 +194,12 @@ export default function Home() {
     setActiveTab(tab);
     setShowSavedOnly(false);
     setError(null);
+    // Reset sort to default when switching tabs
+    if (tab === "papers") {
+      setPaperSort("submittedDate");
+    } else {
+      setYoutubeSort("date");
+    }
   };
 
   const isBookmarked = (id: string) => bookmarks.some((b) => b.id === id);
@@ -443,6 +458,10 @@ export default function Home() {
           onSearch={handleSearch}
           searchQuery={searchQuery}
           bookmarkCount={bookmarks.length}
+          paperSort={paperSort}
+          youtubeSort={youtubeSort}
+          onPaperSortChange={setPaperSort}
+          onYoutubeSortChange={setYoutubeSort}
         />
         {renderContent()}
       </div>


### PR DESCRIPTION
## 概要

検索結果のソート機能を追加します。

closes #14

## 変更内容

### バックエンド

- `/api/news`: `sortBy` パラメータ追加（`submittedDate` / `relevance` / `lastUpdatedDate`）
- `/api/youtube`: `order` パラメータ追加（`date` / `relevance` / `viewCount` / `rating`）
- 両APIとも無効な値に対するバリデーション付き

### フロントエンド

- `Header.tsx`: タブ横にソートドロップダウンを追加（タブに応じて選択肢が切り替わる）
- `page.tsx`: ソート状態管理を追加、ソート変更で自動再フェッチ、タブ切り替え時にデフォルトリセット

## 検証

- ✅ `npm run build` 成功
