### PR TITLE
feat: ダークモード対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "fast-xml-parser": "^5.3.3",
+        "lucide-react": "^0.575.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
@@ -4869,6 +4871,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5035,6 +5046,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "fast-xml-parser": "^5.3.3",
+    "lucide-react": "^0.575.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import ThemeToggle from "./ThemeToggle";
+
 export type PaperSortOption = "submittedDate" | "relevance" | "lastUpdatedDate";
 export type YouTubeSortOption = "date" | "relevance" | "viewCount" | "rating";
 
@@ -38,10 +40,10 @@ export default function Header({
     <header className="mb-8">
       <div className="flex flex-col sm:flex-row justify-between items-center gap-4 mb-6">
         <div className="text-center sm:text-left">
-          <h1 className="text-3xl sm:text-4xl font-extrabold text-indigo-700 tracking-tight">
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-indigo-700 dark:text-indigo-400 tracking-tight">
             RoboDigest
           </h1>
-          <p className="mt-2 text-slate-600">
+          <p className="mt-2 text-slate-600 dark:text-slate-400">
             Robotics Research Dashboard{" "}
             {searchQuery && !showSavedOnly && `for "${searchQuery}"`}
             {showSavedOnly && " (Favorites)"}
@@ -49,12 +51,14 @@ export default function Header({
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3 items-center w-full sm:w-auto">
+          <ThemeToggle />
+
           <button
             onClick={onToggleSaved}
             className={`px-4 py-2 rounded-lg font-medium transition flex items-center gap-2 ${
               showSavedOnly
-                ? "bg-yellow-100 text-yellow-700 border-yellow-200 border"
-                : "bg-white text-slate-600 border border-slate-300 hover:bg-slate-50"
+                ? "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 border-yellow-200 dark:border-yellow-700 border"
+                : "bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-300 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700"
             }`}
           >
             <svg
@@ -82,7 +86,7 @@ export default function Header({
                   ? "Search papers..."
                   : "Search YouTube..."
               }
-              className="px-4 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full sm:w-64"
+              className="px-4 py-2 border border-slate-300 dark:border-slate-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 w-full sm:w-64 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500"
               value={keyword}
               onChange={(e) => onKeywordChange(e.target.value)}
               suppressHydrationWarning={true}
@@ -99,46 +103,48 @@ export default function Header({
 
       {/* Tabs + Sort */}
       {!showSavedOnly && (
-        <div className="flex items-center justify-between border-b border-slate-200">
+        <div className="flex items-center justify-between border-b border-slate-200 dark:border-slate-700">
           <div className="flex">
             <button
               onClick={() => onTabChange("papers")}
               className={`px-6 py-3 font-medium text-sm transition-colors relative ${
                 activeTab === "papers"
-                  ? "text-indigo-700"
-                  : "text-slate-500 hover:text-slate-700"
+                  ? "text-indigo-700 dark:text-indigo-400"
+                  : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300"
               }`}
             >
               📄 論文
               {activeTab === "papers" && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-700 rounded-full" />
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-700 dark:bg-indigo-400 rounded-full" />
               )}
             </button>
             <button
               onClick={() => onTabChange("youtube")}
               className={`px-6 py-3 font-medium text-sm transition-colors relative ${
                 activeTab === "youtube"
-                  ? "text-red-600"
-                  : "text-slate-500 hover:text-slate-700"
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300"
               }`}
             >
               ▶ YouTube
               {activeTab === "youtube" && (
-                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-600 rounded-full" />
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-red-600 dark:bg-red-400 rounded-full" />
               )}
             </button>
           </div>
 
           {/* Sort dropdown */}
           <div className="flex items-center gap-2 pb-1">
-            <label className="text-xs text-slate-400">並び替え</label>
+            <label className="text-xs text-slate-400 dark:text-slate-500">
+              並び替え
+            </label>
             {activeTab === "papers" ? (
               <select
                 value={paperSort}
                 onChange={(e) =>
                   onPaperSortChange(e.target.value as PaperSortOption)
                 }
-                className="text-sm border border-slate-300 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="text-sm border border-slate-300 dark:border-slate-700 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
                 <option value="submittedDate">📅 新着順</option>
                 <option value="relevance">🔍 関連度順</option>
@@ -150,7 +156,7 @@ export default function Header({
                 onChange={(e) =>
                   onYoutubeSortChange(e.target.value as YouTubeSortOption)
                 }
-                className="text-sm border border-slate-300 rounded-lg px-3 py-1.5 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="text-sm border border-slate-300 dark:border-slate-700 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-red-500"
               >
                 <option value="date">📅 新着順</option>
                 <option value="relevance">🔍 関連度順</option>

--- a/src/app/components/PaperCard.tsx
+++ b/src/app/components/PaperCard.tsx
@@ -18,10 +18,10 @@ export default function PaperCard({
   onSummarize,
 }: PaperCardProps) {
   return (
-    <article className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow border border-slate-100 overflow-hidden flex flex-col relative group">
+    <article className="bg-white dark:bg-slate-900 rounded-xl shadow-sm hover:shadow-md transition-shadow border border-slate-100 dark:border-slate-800 overflow-hidden flex flex-col relative group">
       <button
         onClick={(e) => onToggleBookmark(paper, e)}
-        className="absolute top-4 right-4 z-10 p-2 text-yellow-400 hover:text-yellow-500 hover:bg-yellow-50 rounded-full transition"
+        className="absolute top-4 right-4 z-10 p-2 text-yellow-400 hover:text-yellow-500 hover:bg-yellow-50 dark:hover:bg-yellow-900/30 rounded-full transition"
         title={isBookmarked ? "お気に入り解除" : "お気に入り追加"}
       >
         {isBookmarked ? (
@@ -54,7 +54,7 @@ export default function PaperCard({
       <div className="p-6 flex-1">
         {paper.category && (
           <div className="flex justify-between items-start mb-3">
-            <span className="inline-block px-3 py-1 text-xs font-semibold text-indigo-600 bg-indigo-50 rounded-full">
+            <span className="inline-block px-3 py-1 text-xs font-semibold text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 rounded-full">
               {paper.category}
             </span>
           </div>
@@ -62,10 +62,10 @@ export default function PaperCard({
 
         {paper.title_ja ? (
           <>
-            <h2 className="text-xl font-bold text-slate-800 leading-snug mb-2 pr-8">
+            <h2 className="text-xl font-bold text-slate-800 dark:text-slate-100 leading-snug mb-2 pr-8">
               {paper.title_ja}
             </h2>
-            <ul className="space-y-2 text-sm text-slate-600 mt-4 mb-4">
+            <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-400 mt-4 mb-4">
               {paper.points?.map((point, i) => (
                 <li key={i} className="flex gap-2 items-start">
                   <span className="text-indigo-400 mt-1">•</span>
@@ -76,10 +76,10 @@ export default function PaperCard({
           </>
         ) : (
           <>
-            <h2 className="text-lg font-semibold text-slate-800 leading-snug mb-2 pr-8">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100 leading-snug mb-2 pr-8">
               {paper.title}
             </h2>
-            <p className="text-sm text-slate-500 line-clamp-4 mb-4">
+            <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-4 mb-4">
               {paper.summary}
             </p>
           </>
@@ -91,10 +91,10 @@ export default function PaperCard({
           <button
             onClick={() => onSummarize(paper)}
             disabled={isSummarizing}
-            className="w-full py-2 px-4 bg-indigo-50 text-indigo-700 font-medium rounded-lg hover:bg-indigo-100 transition-colors text-sm flex justify-center items-center"
+            className="w-full py-2 px-4 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 font-medium rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors text-sm flex justify-center items-center"
           >
             {isSummarizing ? (
-              <span className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-700 mr-2"></span>
+              <span className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-700 dark:border-indigo-400 mr-2"></span>
             ) : (
               "✨ AI要約する"
             )}
@@ -104,7 +104,7 @@ export default function PaperCard({
           href={paper.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="block w-full text-center py-2 px-4 bg-slate-900 text-white font-medium rounded-lg hover:bg-slate-800 transition-colors text-sm"
+          className="block w-full text-center py-2 px-4 bg-slate-900 dark:bg-slate-700 text-white font-medium rounded-lg hover:bg-slate-800 dark:hover:bg-slate-600 transition-colors text-sm"
         >
           原文を読む
         </a>

--- a/src/app/components/SkeletonCard.tsx
+++ b/src/app/components/SkeletonCard.tsx
@@ -6,15 +6,17 @@ type SkeletonCardProps = {
 
 export default function SkeletonCard({ variant = "paper" }: SkeletonCardProps) {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-100 overflow-hidden animate-pulse">
-      {variant === "video" && <div className="h-48 bg-slate-200" />}
+    <div className="bg-white dark:bg-slate-900 rounded-xl shadow-sm border border-slate-100 dark:border-slate-800 overflow-hidden animate-pulse">
+      {variant === "video" && (
+        <div className="h-48 bg-slate-200 dark:bg-slate-700" />
+      )}
       <div className="p-6">
-        <div className="h-4 bg-slate-200 rounded w-1/3 mb-4"></div>
-        <div className="h-6 bg-slate-200 rounded w-3/4 mb-4"></div>
+        <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-1/3 mb-4"></div>
+        <div className="h-6 bg-slate-200 dark:bg-slate-700 rounded w-3/4 mb-4"></div>
         <div className="space-y-2 mb-6">
-          <div className="h-4 bg-slate-200 rounded"></div>
-          <div className="h-4 bg-slate-200 rounded"></div>
-          <div className="h-4 bg-slate-200 rounded w-5/6"></div>
+          <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded"></div>
+          <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded"></div>
+          <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-5/6"></div>
         </div>
       </div>
     </div>

--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Sun, Moon, Monitor } from "lucide-react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div className="w-[7.5rem] h-9 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800" />
+    );
+  }
+
+  const Icon = theme === "dark" ? Moon : theme === "light" ? Sun : Monitor;
+
+  return (
+    <div className="relative flex items-center">
+      <Icon className="absolute left-2.5 h-4 w-4 text-slate-500 dark:text-slate-400 pointer-events-none" />
+      <select
+        value={theme}
+        onChange={(e) => setTheme(e.target.value)}
+        className="appearance-none pl-8 pr-3 py-2 text-sm text-right leading-none rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 cursor-pointer"
+        aria-label="テーマ切り替え"
+      >
+        <option value="light">ライト</option>
+        <option value="dark">ダーク</option>
+        <option value="system">システム</option>
+      </select>
+    </div>
+  );
+}

--- a/src/app/components/VideoCard.tsx
+++ b/src/app/components/VideoCard.tsx
@@ -18,10 +18,10 @@ export default function VideoCard({
   onSummarize,
 }: VideoCardProps) {
   return (
-    <article className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow border border-slate-100 overflow-hidden flex flex-col relative group">
+    <article className="bg-white dark:bg-slate-900 rounded-xl shadow-sm hover:shadow-md transition-shadow border border-slate-100 dark:border-slate-800 overflow-hidden flex flex-col relative group">
       <button
         onClick={(e) => onToggleBookmark(video, e)}
-        className="absolute top-4 right-4 z-10 p-2 text-yellow-400 hover:text-yellow-500 hover:bg-yellow-50 rounded-full transition"
+        className="absolute top-4 right-4 z-10 p-2 text-yellow-400 hover:text-yellow-500 hover:bg-yellow-50 dark:hover:bg-yellow-900/30 rounded-full transition"
         title={isBookmarked ? "お気に入り解除" : "お気に入り追加"}
       >
         {isBookmarked ? (
@@ -66,7 +66,7 @@ export default function VideoCard({
       <div className="p-5 flex-1">
         {video.category && (
           <div className="flex justify-between items-start mb-3">
-            <span className="inline-block px-3 py-1 text-xs font-semibold text-red-600 bg-red-50 rounded-full">
+            <span className="inline-block px-3 py-1 text-xs font-semibold text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30 rounded-full">
               {video.category}
             </span>
           </div>
@@ -74,10 +74,10 @@ export default function VideoCard({
 
         {video.title_ja ? (
           <>
-            <h2 className="text-xl font-bold text-slate-800 leading-snug mb-2 pr-8">
+            <h2 className="text-xl font-bold text-slate-800 dark:text-slate-100 leading-snug mb-2 pr-8">
               {video.title_ja}
             </h2>
-            <ul className="space-y-2 text-sm text-slate-600 mt-4 mb-4">
+            <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-400 mt-4 mb-4">
               {video.points?.map((point, i) => (
                 <li key={i} className="flex gap-2 items-start">
                   <span className="text-red-400 mt-1">•</span>
@@ -88,16 +88,16 @@ export default function VideoCard({
           </>
         ) : (
           <>
-            <h2 className="text-base font-semibold text-slate-800 leading-snug mb-2 pr-8">
+            <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 leading-snug mb-2 pr-8">
               {video.title}
             </h2>
-            <p className="text-sm text-slate-500 line-clamp-2 mb-2">
+            <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2 mb-2">
               {video.description}
             </p>
           </>
         )}
 
-        <div className="flex items-center gap-2 text-xs text-slate-400 mt-2">
+        <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500 mt-2">
           <span>{video.channelTitle}</span>
           <span>•</span>
           <span>{new Date(video.publishedAt).toLocaleDateString("ja-JP")}</span>
@@ -109,10 +109,10 @@ export default function VideoCard({
           <button
             onClick={() => onSummarize(video)}
             disabled={isSummarizing}
-            className="w-full py-2 px-4 bg-red-50 text-red-700 font-medium rounded-lg hover:bg-red-100 transition-colors text-sm flex justify-center items-center"
+            className="w-full py-2 px-4 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400 font-medium rounded-lg hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors text-sm flex justify-center items-center"
           >
             {isSummarizing ? (
-              <span className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-red-700 mr-2"></span>
+              <span className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-red-700 dark:border-red-400 mr-2"></span>
             ) : (
               "✨ AI要約する"
             )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -12,11 +14,9 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,11 +25,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -315,7 +315,7 @@ export default function Home() {
       if (bookmarks.length === 0) {
         return (
           <div className="text-center py-20">
-            <p className="text-slate-500 text-lg">
+            <p className="text-slate-500 dark:text-slate-400 text-lg">
               お気に入りのコンテンツはまだありません。
             </p>
           </div>
@@ -379,7 +379,7 @@ export default function Home() {
       if (papers.length === 0) {
         return (
           <div className="text-center py-20">
-            <p className="text-slate-500 text-lg">
+            <p className="text-slate-500 dark:text-slate-400 text-lg">
               論文が見つかりませんでした。
             </p>
           </div>
@@ -405,7 +405,9 @@ export default function Home() {
     if (videos.length === 0) {
       return (
         <div className="text-center py-20">
-          <p className="text-slate-500 text-lg">動画が見つかりませんでした。</p>
+          <p className="text-slate-500 dark:text-slate-400 text-lg">
+            動画が見つかりませんでした。
+          </p>
         </div>
       );
     }
@@ -446,7 +448,7 @@ export default function Home() {
   };
 
   return (
-    <main className="min-h-screen bg-slate-50 text-slate-900 p-4 sm:p-8">
+    <main className="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 p-4 sm:p-8">
       <div className="max-w-6xl mx-auto">
         <Header
           activeTab={activeTab}


### PR DESCRIPTION
# ダークモード対応 — 実装完了

`feature/dark-mode` ブランチで以下を実装しました。

## 新規ファイル

- `ThemeProvider.tsx` — `next-themes`のラッパー
- `ThemeToggle.tsx` — テーマ切り替えプルダウン（ライト/ダーク/システム）

## 変更ファイル

- `globals.css` — `@custom-variant dark` でクラスベースのダークモード有効化
- `layout.tsx` — `ThemeProvider` で全体をラップ
- `page.tsx` — メイン背景・テキストに `dark:` クラス追加
- `Header.tsx` — `ThemeToggle` を配置、全要素に `dark:` クラス追加
- `PaperCard.tsx` / `VideoCard.tsx` / `SkeletonCard.tsx` — ダークモード配色適用

## 主な機能

- ☀️/🌙/🖥 プルダウンで3モード切り替え（ライト / ダーク / システム）
- テーマ設定は `localStorage` に保存、リロード後も維持
- `npm run build` ✅ TypeScriptエラーなし
